### PR TITLE
add ability to deploy manifest

### DIFF
--- a/scripts/k8s/cluster.bash
+++ b/scripts/k8s/cluster.bash
@@ -121,6 +121,6 @@ function deploy_k8s_manifests()
 {
     get_credentials
     create_ns_if_doesnt_exists manifests
-    cd configs/env/${env_name}/manifests/
+    cd manifests/${env_name}
     ls | xargs kubectl apply -n manifests -f 
 }

--- a/scripts/k8s/cluster.bash
+++ b/scripts/k8s/cluster.bash
@@ -120,5 +120,7 @@ function deploy_k8s_cert_manager()
 function deploy_k8s_manifests()
 {
     get_credentials
-    ls configs/env/${env_name}/manifests/ | xargs kubectl apply -f
+    create_ns_if_doesnt_exists manifests
+    cd configs/env/${env_name}/manifests/
+    ls | xargs kubectl apply -n manifests -f 
 }

--- a/scripts/k8s/cluster.bash
+++ b/scripts/k8s/cluster.bash
@@ -24,8 +24,11 @@ function create_k8s_cluster()
         --disk-type "${env_k8s_nodes_disk_type}" \
         --disk-size "${env_k8s_nodes_disk_size}" \
         --num-nodes ${env_k8s_nodes_count} \
-        --network "default" \
-        --subnetwork "default" \
+        --enable-ip-alias \
+        --network ${env_k8s_network_name} \
+        --create-subnetwork name=${env_k8s_network_subnet},range=${env_k8s_network_ip_range} \
+        --cluster-ipv4-cidr ${env_k8s_network_pod_ip_range} \
+        --services-ipv4-cidr ${env_k8s_network_services_ip_range} \
         --addons HorizontalPodAutoscaling,HttpLoadBalancing \
         --no-enable-autoupgrade \
         --enable-autorepair


### PR DESCRIPTION
https://github.com/acretrader/general/issues/4536
Add ability to deploy manifest from manifests folder
The manifest folder consists of 3 envs
- dev
- stage
- master

Using for deploy some manifests not default for apps.
One of these manifests is the sendgrid proxy. 
Sendgrid proxy is a service with an SSL certificate that proxies for all requests to sendgrid.net
Related documentation - https://docs.sendgrid.com/ui/account-and-settings/custom-ssl-configurations
