### PR TITLE
Use current k8s image tags (if exist)

### DIFF
--- a/k8s/apps/deployment.yaml
+++ b/k8s/apps/deployment.yaml
@@ -151,7 +151,7 @@ spec:
           {%- if app.get('imagePullPolicy', '') != '' %}
           imagePullPolicy: "{{ app.imagePullPolicy }}"
           {%- else %}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           {%- endif %}
           {%- if app.command is defined %}
           command: {{ app.command }}


### PR DESCRIPTION
@vladyslav2 добавил шаг по замене image в манифесте на текущую используемую версию

1) Если сервис уже задеплоен, то береться его текущая версия образа и проставляеться в итоговом манифесте на этапе render-a
2) Если сервис ещё небыл задеплоен, то render происходит как обычно и мы ставим версию latest


Пример:

```
└─ $ >  ./scripts/k8s/deploy_apps.bash render_templates offer-api
Render 1_namespace.yaml for apps/offer-api.yaml
Render certificate.yaml for apps/offer-api.yaml
Render configmap.yaml for apps/offer-api.yaml
Render cronjob.yaml for apps/offer-api.yaml
Render deployment.yaml for apps/offer-api.yaml
Image replaced to current version cr.webdevelop.us/webdevelop-pro/offer-api:c1447e23
```

таким образом мы не будем менять образы когда делаем `kubectl apply` а latest будет использоваться только в случае если сервис не задеплоен, но так бывает в основном только когда мы заново деплоем с 0 и в этом случае старых образов на серверах нет