### PR TITLE
Update make.sh for run integration tests

### DIFF
--- a/cloud-builders/go-common/etc/make.sh
+++ b/cloud-builders/go-common/etc/make.sh
@@ -80,12 +80,12 @@ test)
   case $2 in
   unit)
     init
-    go test -run=Unit -count=1 ${PKG_LIST} $2 $3
+    go test -run=Unit -count=1 ${PKG_LIST} $3
     ;;
 
   integration)
     init
-    go test -run=Integration -count=1 ${PKG_LIST} $2 $3
+    go test -run=Integration -count=1 ${PKG_LIST} $3
     ;;
   *)
       init

--- a/cloud-builders/go-common/etc/make.sh
+++ b/cloud-builders/go-common/etc/make.sh
@@ -80,16 +80,16 @@ test)
   case $2 in
   unit)
     init
-    go test -run=Unit -count=1 ${PKG_LIST} $3
+    go test -run=Unit -count=1 -v ${PKG_LIST} $3
     ;;
 
   integration)
     init
-    go test -run=Integration -count=1 -p 1 ${PKG_LIST} $3
+    go test -run=Integration -count=1 -p 1 -v ${PKG_LIST} $3
     ;;
   *)
       init
-      go test -count=1 -p 1 ${PKG_LIST} $2 $3
+      go test -count=1 -p 1 -v ${PKG_LIST} $2 $3
     ;;
 
     esac

--- a/cloud-builders/go-common/etc/make.sh
+++ b/cloud-builders/go-common/etc/make.sh
@@ -85,11 +85,11 @@ test)
 
   integration)
     init
-    go test -run=Integration -count=1 ${PKG_LIST} $3
+    go test -run=Integration -count=1 -p 1 ${PKG_LIST} $3
     ;;
   *)
       init
-      go test -count=1 ${PKG_LIST} $2 $3
+      go test -count=1 -p 1 ${PKG_LIST} $2 $3
     ;;
 
     esac


### PR DESCRIPTION
Это для того что бы ./make.sh test integration работал, $2 = integration в данном случае