### PR TITLE
Add startup delay 10s

### DIFF
--- a/k8s/apps/deployment.yaml
+++ b/k8s/apps/deployment.yaml
@@ -207,6 +207,11 @@ spec:
           {%- endfor %}
           {%- endif %}
 
+          startupProbe:
+            exec:
+              command: ["echo"]
+            initialDelaySeconds: 10
+
           {%- if app.get('helthcheck', {}).get('enable', false) %}
           readinessProbe:
             failureThreshold: 3


### PR DESCRIPTION
@vladyslav2 я добавил 10s задержку перед тем как под перейдет в Running статус, что бы дать время на проверку того что под не упадет после запуска. Это нужно потому что у нас нет healthcheck-ов для воркеров а для API у нас они не очень с этим справляються т.к. бывает такое что под поднимаеться потом ему приходит какой то запрос или сообщение из очереди и он падает