### PR TITLE
Update golangci.yml

### DIFF
--- a/cloud-builders/go-common/etc/golangci.yml
+++ b/cloud-builders/go-common/etc/golangci.yml
@@ -24,6 +24,12 @@ linters:
     - wsl
     - tagalign
     - varnamelen
+    - godox
+    - funlen
+    - gci
+    - gocognit
+    - interfacebloat
+    - cyclop
 
 linters-settings:
   cyclop:

--- a/cloud-builders/go-common/etc/golangci.yml
+++ b/cloud-builders/go-common/etc/golangci.yml
@@ -26,7 +26,6 @@ linters:
     - varnamelen
     - godox
     - funlen
-    - gci
     - gocognit
     - interfacebloat
     - cyclop


### PR DESCRIPTION
@vladyslav2 чуть расширил наш игнор список для go линтера.

1) godox - что бы не ругалось на TODO в коде
2) funlen - какой то слишком строгий к названию функций, думаю нам достаточно обычного линта который првоверяет длинну строк
3) gci тут я не понял как обойти эту ошибку
```
internal/adapters/db/postgres.go:7: File is not `gci`-ed with --skip-generated -s standard -s default (gci)
        "github.com/pkg/errors"

internal/adapters/db/postgres.go:11: File is not `gci`-ed with --skip-generated -s standard -s default (gci)
        "github.com/jackc/pgx/v5/pgxpool"
cmd/http/start/start.go:7: File is not `gci`-ed with --skip-generated -s standard -s default (gci)
        "github.com/webdevelop-pro/go-common/configurator"
```
4) gocognit и cyclop - ругаеться на наши длинные функции где много работы с разными моделями и соответсвенно valid/select методами
5) interfacebloat - пока мы все запихиваем в один интерфейс то нам нужно это заигнорить